### PR TITLE
Fix virus movement rotation

### DIFF
--- a/core/src/com/tds/Virus.java
+++ b/core/src/com/tds/Virus.java
@@ -47,8 +47,8 @@ public class Virus extends Entity{
         double angle = Math.atan2(-dirX, dirY);
         float x, y;
         
-        x = (float)Math.cos(angle + 90f) * getSpeed() * Gdx.graphics.getDeltaTime();
-        y = (float)Math.sin(angle + 90f) * getSpeed() * Gdx.graphics.getDeltaTime();
+        x = (float)Math.cos(angle + Math.PI / 2) * getSpeed() * Gdx.graphics.getDeltaTime();
+        y = (float)Math.sin(angle + Math.PI / 2) * getSpeed() * Gdx.graphics.getDeltaTime();
         this.translate(x, y);
     }
     


### PR DESCRIPTION
## Summary
- fix incorrect radian conversion in `Virus.move`

## Testing
- `./gradlew test` *(fails: HTTP 403 downloading gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_688928a458248325be86352b24c6f9b1