### PR TITLE
Add README with build and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# TDS
+
+## Prerequisites
+- JDK 17 or newer
+- This project ships with a Gradle wrapper (version 8.5). Verify with:
+
+```bash
+./gradlew --version
+```
+
+## Build
+```bash
+./gradlew build
+```
+
+## Test
+```bash
+./gradlew test
+```
+
+## Run
+```bash
+./gradlew desktop:run
+```
+
+## macOS notes
+- Ensure the Gradle wrapper is executable:
+
+```bash
+chmod +x gradlew
+```
+
+- The desktop client may require running on the first thread:
+
+```bash
+./gradlew desktop:run -Dorg.gradle.jvmargs=-XstartOnFirstThread
+```


### PR DESCRIPTION
## Summary
- Add root README with prerequisites, build/test/run commands and macOS notes.

## Testing
- `./gradlew --version` *(fails: unable to access gradle-wrapper.jar)*
- `./gradlew build` *(fails: unable to access gradle-wrapper.jar)*
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*
- `./gradlew desktop:run` *(fails: unable to access gradle-wrapper.jar)*
- `gradle build`
- `gradle test`
- `gradle desktop:run` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_68a3708e13008325908c6eb3322df8c5