### PR TITLE
Handle macOS first-thread requirement for desktop run task

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -17,6 +17,9 @@ task run(dependsOn: classes, type: JavaExec) {
     standardInput = System.in
     workingDir = project.assetsDir
     ignoreExitValue = true
+    if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        jvmArgs += ["-XstartOnFirstThread"]
+    }
 }
 
 task dist(type: Jar) {


### PR DESCRIPTION
## Summary
- Ensure the desktop run task sets `-XstartOnFirstThread` when running on macOS.

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew desktop:run` *(fails: No X11 DISPLAY variable was set)*

------
https://chatgpt.com/codex/tasks/task_e_68a38343b9048325a621630ecc37703f