### PR TITLE
Document generating Gradle wrapper jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,6 @@ build/
 
 ## OS Specific
 .DS_Store
+
+# Generated Gradle wrapper JAR
 gradle/wrapper/gradle-wrapper.jar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,13 @@
 This repository is a small LibGDX project split into `core` and `desktop` modules.
 
 ## Building
-Use the provided Gradle wrapper:
+The Gradle wrapper JAR is not committed. If `gradle/wrapper/gradle-wrapper.jar` is missing, generate it with:
+
+```
+gradle wrapper --gradle-version 8.5
+```
+
+Then use the wrapper:
 
 ```
 ./gradlew build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## Prerequisites
 - JDK 17 or newer
-- This project ships with a Gradle wrapper (version 8.5). Verify with:
+- Gradle wrapper scripts target Gradle 8.5. If `gradle/wrapper/gradle-wrapper.jar` is missing, generate it with:
+
+```bash
+gradle wrapper --gradle-version 8.5
+```
+
+Verify with:
 
 ```bash
 ./gradlew --version


### PR DESCRIPTION
## Summary
- remove committed Gradle wrapper JAR and ignore it
- document how to regenerate the wrapper JAR if absent
- note wrapper generation step in AGENTS instructions

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3841125588325b63e055b704b7249