### PR TITLE
Upgrade LibGDX backend for Apple Silicon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ allprojects {
     version = '1.0'
     ext {
         appName = "TDS"
-        gdxVersion = '1.9.2'
+        gdxVersion = '1.12.1'
         roboVMVersion = '1.12.0'
         box2DLightsVersion = '1.4'
         ashleyVersion = '1.7.0'
@@ -32,7 +32,7 @@ project(":desktop") {
 
     dependencies {
         implementation project(":core")
-        implementation "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
         implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
         implementation "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
     }

--- a/desktop/src/com/tds/desktop/DesktopLauncher.java
+++ b/desktop/src/com/tds/desktop/DesktopLauncher.java
@@ -1,19 +1,16 @@
 package com.tds.desktop;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.Graphics.DisplayMode;
 import com.tds.TDS;
-import java.awt.Toolkit;
-import java.awt.Dimension;
 
 
 public class DesktopLauncher {
-	public static void main (String[] arg) {
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-                config.width = (int)screenSize.getWidth();
-                config.height = (int)screenSize.getHeight();
-                config.fullscreen = true;
-		new LwjglApplication(new TDS(), config);
-	}
+        public static void main (String[] arg) {
+                Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+                DisplayMode displayMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+                config.setFullscreenMode(displayMode);
+                new Lwjgl3Application(new TDS(), config);
+        }
 }


### PR DESCRIPTION
## Summary
- update LibGDX to 1.12.1 and use LWJGL3 backend to include macOS ARM64 natives
- revise desktop launcher to use Lwjgl3Application with fullscreen configuration

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a387b340f88325983f3ac4e62d5da8