### PR TITLE
chore: update Gradle and library versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is a small LibGDX project split into `core` and `desktop` module
 The Gradle wrapper JAR is not committed. If `gradle/wrapper/gradle-wrapper.jar` is missing, generate it with:
 
 ```
-gradle wrapper --gradle-version 8.5
+gradle wrapper --gradle-version 8.9
 ```
 
 Then use the wrapper:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Prerequisites
 - JDK 17 or newer
-- Gradle wrapper scripts target Gradle 8.5. If `gradle/wrapper/gradle-wrapper.jar` is missing, generate it with:
+- Gradle wrapper scripts target Gradle 8.9. If `gradle/wrapper/gradle-wrapper.jar` is missing, generate it with:
 
 ```bash
-gradle wrapper --gradle-version 8.5
+gradle wrapper --gradle-version 8.9
 ```
 
 Verify with:

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,11 @@ allprojects {
     version = '1.0'
     ext {
         appName = "TDS"
-        gdxVersion = '1.12.1'
-        roboVMVersion = '1.12.0'
-        box2DLightsVersion = '1.4'
-        ashleyVersion = '1.7.0'
-        aiVersion = '1.8.0'
+        gdxVersion = '1.13.5'
+        roboVMVersion = '1.14.0'
+        box2DLightsVersion = '1.5'
+        ashleyVersion = '1.7.4'
+        aiVersion = '1.8.2'
     }
 
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update Gradle wrapper to 8.9
- bump LibGDX libraries (gdx, box2DLights, ashley, ai, RoboVM)
- refresh docs for new Gradle version

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a38a82b8a08325b43cd72d6ea49ab9