### PR TITLE
Refactor to Game architecture with screens

### DIFF
--- a/core/src/com/tds/Admin.java
+++ b/core/src/com/tds/Admin.java
@@ -125,8 +125,12 @@ public class Admin extends Entity{
     void draw(SpriteBatch batch) {
         super.draw(batch);
     }
-    
-    void wallCollison(Wall wall){
+
+    public void drawBullets(SpriteBatch batch) {
+        bullets.draw(batch);
+    }
+
+    public void wallCollison(Wall wall){
         Rectangle r1 = wall.getBoundingRectangle();
         Rectangle r2 = this.getBoundingRectangle();
         

--- a/core/src/com/tds/TDS.java
+++ b/core/src/com/tds/TDS.java
@@ -1,187 +1,30 @@
 package com.tds;
 
-import com.badlogic.gdx.ApplicationAdapter;
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
-import com.badlogic.gdx.Input.Keys;
-import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.InputProcessor;
-import com.badlogic.gdx.graphics.g2d.Sprite;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
-import com.badlogic.gdx.graphics.Color;
-import java.util.ArrayList;
-import java.util.Random;
+import com.tds.screen.MenuScreen;
 
-public class TDS extends ApplicationAdapter {
-    HUD hud;
-    SpriteBatch batch;
-    Admin admin;
-    Texture img;
-    Texture background;
-    float posx;
-    float posy;
-    float mouseX, mouseY;
-    float speed;
-    int level;
-    BitmapFont pen;
-    Texture virusTexture;
-    Virus v1;
-    ArrayList<Virus> virusList;
-    Wall[] walls;
-    
+public class TDS extends Game {
+    public SpriteBatch batch;
+    public AssetManager assetManager;
+
     @Override
     public void create () {
-        hud = new HUD();
         batch = new SpriteBatch();
-        img = new Texture("badlogic.jpg");
-        
-        background = new Texture("background.png");
-        
-        admin = new Admin(1, 3, 1, 300, img);
-        posx = Gdx.graphics.getWidth()/2 - admin.getWidth()/2;
-        posy = Gdx.graphics.getHeight()/2 - admin.getHeight()/2;
-        admin.setPosition(posx, posy);
-        admin.scale(.2f);
-        
-        virusTexture = new Texture("virus.png");
-        
-        virusList = new ArrayList<Virus>();
-        level = 1;
-        
-        generateLevel(level);
-        //v1 = new Virus(virusTexture);
-        //v1.setPosition(40, 40);
-        
-        pen = new BitmapFont();
-        pen.setColor(Color.YELLOW);
-
-        
-        walls = new Wall[4];
-        
-        int gap = 200;
-        int wallWidth = 50;
-        int worldHeight = Gdx.graphics.getHeight();
-        int worldWidth = Gdx.graphics.getWidth();
-        // Bottom wall
-        Wall temp = new Wall();
-        temp.setSize(worldWidth - gap, wallWidth);
-        temp.setPosition(gap / 2, 0);
-        walls[0] = temp;
-        // Top wall
-        temp = new Wall();
-        temp.setSize(worldWidth - gap, wallWidth);
-        temp.setPosition(gap / 2, worldHeight - wallWidth);
-        walls[1] = temp;
-        // Left wall
-        temp = new Wall();
-        temp.setSize(wallWidth, worldHeight - gap);
-        temp.setPosition(0, gap / 2);
-        walls[2] = temp;
-        // Right wall
-        temp = new Wall();
-        temp.setSize(wallWidth, worldHeight - gap);
-        temp.setPosition(worldWidth - wallWidth, gap / 2);
-        walls[3] = temp;
+        assetManager = new AssetManager();
+        assetManager.load("badlogic.jpg", Texture.class);
+        assetManager.load("background.png", Texture.class);
+        assetManager.load("virus.png", Texture.class);
+        assetManager.finishLoading();
+        setScreen(new MenuScreen(this));
     }
 
     @Override
-    public void render () {
-        admin.processMovement(virusList);   
-        //v1.move(admin.getX() + admin.getWidth()/2, 
-          //      admin.getY() + admin.getHeight()/2);
-        Gdx.gl.glClearColor(.1f, .1f, .1f, 1);
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-        
-        if(Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)){
-            System.exit(0);
-        }
-        hud.setCurrentLives(admin.getLives());
-        
-
-        for(Wall wall : walls){
-            admin.wallCollison(wall);
-        }
-        
-        batch.begin();
-        batch.draw(background, 0, 0);
-        for(Wall wall : walls){
-            if(wall != null){
-                //wall.draw(batch);
-            }
-        }
-        
-        for(Virus v : virusList){
-            v.move(admin.getX() + admin.getWidth()/2, 
-                    admin.getY() + admin.getHeight()/2);
-            if( admin.getBoundingRectangle().overlaps(v.getBoundingRectangle()) ) {
-                v.setStatus(false);
-                admin.setPosition(Gdx.graphics.getWidth()/2, 
-                        Gdx.graphics.getHeight()/2);
-                admin.setLives(admin.getLives()-1);
-                if( admin.getLives() <= 0 ){
-                    System.exit(0);
-                }
-            }
-        }
-        
-        admin.draw(batch);
-        admin.bullets.draw(batch);
-
-        for(Virus v : virusList) {
-            v.draw(batch);
-        }
-        
-        //v1.draw(batch);
-        //v1.move(admin.getX(), admin.getY());
-        hud.drawHud(batch, pen);
-        
-        batch.end();
-        for(int i = virusList.size() - 1; i >= 0; i-- ) {
-            if(virusList.get(i).getStatus() != true) {
-                hud.setTotalScore(hud.getTotalScore() + 1);
-                virusList.remove(virusList.get(i));                
-            }
-        }
-        
-        if(virusList.size() == 0){
-            level += 1;
-            hud.incrementCurrentLevel();
-            generateLevel(level);
-        }
-    }
-    
-    void generateLevel(int levelNumber){
-        int numberVirus = levelNumber*2 + levelNumber;
-        for(int i = 0; i < numberVirus; i++) {
-            v1 = new Virus(virusTexture, levelNumber);
-            virusList.add(v1);
-        }
-        Random rand = new Random();
-        for(Virus v : virusList){
-            int pos = rand.nextInt() % 4;
-            switch(pos){
-                case 0:
-                    v.setPosition(40, 40);
-                    break;
-                case 1:
-                    v.setPosition(40, Gdx.graphics.getHeight() - 40);
-                    break;
-                case 2:
-                    v.setPosition(Gdx.graphics.getWidth() - 40, 40);
-                    break;
-                case 3:
-                    v.setPosition(Gdx.graphics.getWidth() - 40, 
-                        Gdx.graphics.getHeight() -40);
-                    break;
-                default:
-                    v.setPosition(Gdx.graphics.getWidth() - 40, 
-                        Gdx.graphics.getHeight() -40);
-                    break;
-            }       
-        }
+    public void dispose() {
+        super.dispose();
+        batch.dispose();
+        assetManager.dispose();
     }
 }

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -1,0 +1,162 @@
+package com.tds.screen;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.tds.Admin;
+import com.tds.HUD;
+import com.tds.TDS;
+import com.tds.Virus;
+import com.tds.Wall;
+
+import java.util.ArrayList;
+import java.util.Random;
+
+public class GameScreen extends ScreenAdapter {
+    private final TDS game;
+    private HUD hud;
+    private Admin admin;
+    private Texture background;
+    private BitmapFont pen;
+    private Texture virusTexture;
+    private ArrayList<Virus> virusList;
+    private Wall[] walls;
+    private int level;
+    private Virus v1;
+
+    public GameScreen(TDS game) {
+        this.game = game;
+    }
+
+    @Override
+    public void show() {
+        hud = new HUD();
+        background = game.assetManager.get("background.png", Texture.class);
+        virusTexture = game.assetManager.get("virus.png", Texture.class);
+
+        admin = new Admin(1, 3, 1, 300, game.assetManager.get("badlogic.jpg", Texture.class));
+        float posx = Gdx.graphics.getWidth()/2 - admin.getWidth()/2;
+        float posy = Gdx.graphics.getHeight()/2 - admin.getHeight()/2;
+        admin.setPosition(posx, posy);
+        admin.scale(.2f);
+
+        virusList = new ArrayList<Virus>();
+        level = 1;
+        generateLevel(level);
+
+        pen = new BitmapFont();
+        pen.setColor(Color.YELLOW);
+
+        walls = new Wall[4];
+        int gap = 200;
+        int wallWidth = 50;
+        int worldHeight = Gdx.graphics.getHeight();
+        int worldWidth = Gdx.graphics.getWidth();
+        Wall temp = new Wall();
+        temp.setSize(worldWidth - gap, wallWidth);
+        temp.setPosition(gap / 2, 0);
+        walls[0] = temp;
+        temp = new Wall();
+        temp.setSize(worldWidth - gap, wallWidth);
+        temp.setPosition(gap / 2, worldHeight - wallWidth);
+        walls[1] = temp;
+        temp = new Wall();
+        temp.setSize(wallWidth, worldHeight - gap);
+        temp.setPosition(0, gap / 2);
+        walls[2] = temp;
+        temp = new Wall();
+        temp.setSize(wallWidth, worldHeight - gap);
+        temp.setPosition(worldWidth - wallWidth, gap / 2);
+        walls[3] = temp;
+    }
+
+    @Override
+    public void render(float delta) {
+        admin.processMovement(virusList);
+        Gdx.gl.glClearColor(.1f, .1f, .1f, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        if(Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)){
+            Gdx.app.exit();
+        }
+        hud.setCurrentLives(admin.getLives());
+
+        for(Wall wall : walls){
+            admin.wallCollison(wall);
+        }
+
+        game.batch.begin();
+        game.batch.draw(background, 0, 0);
+        for(Virus v : virusList){
+            v.move(admin.getX() + admin.getWidth()/2,
+                    admin.getY() + admin.getHeight()/2);
+            if( admin.getBoundingRectangle().overlaps(v.getBoundingRectangle()) ) {
+                v.setStatus(false);
+                admin.setPosition(Gdx.graphics.getWidth()/2,
+                        Gdx.graphics.getHeight()/2);
+                admin.setLives(admin.getLives()-1);
+                if( admin.getLives() <= 0 ){
+                    Gdx.app.exit();
+                }
+            }
+        }
+
+        admin.draw(game.batch);
+        admin.drawBullets(game.batch);
+
+        for(Virus v : virusList) {
+            v.draw(game.batch);
+        }
+
+        hud.drawHud(game.batch, pen);
+
+        game.batch.end();
+        for(int i = virusList.size() - 1; i >= 0; i-- ) {
+            if(virusList.get(i).getStatus() != true) {
+                hud.setTotalScore(hud.getTotalScore() + 1);
+                virusList.remove(virusList.get(i));
+            }
+        }
+
+        if(virusList.size() == 0){
+            level += 1;
+            hud.incrementCurrentLevel();
+            generateLevel(level);
+        }
+    }
+
+    void generateLevel(int levelNumber){
+        int numberVirus = levelNumber*2 + levelNumber;
+        for(int i = 0; i < numberVirus; i++) {
+            v1 = new Virus(virusTexture, levelNumber);
+            virusList.add(v1);
+        }
+        Random rand = new Random();
+        for(Virus v : virusList){
+            int pos = rand.nextInt() % 4;
+            switch(pos){
+                case 0:
+                    v.setPosition(40, 40);
+                    break;
+                case 1:
+                    v.setPosition(40, Gdx.graphics.getHeight() - 40);
+                    break;
+                case 2:
+                    v.setPosition(Gdx.graphics.getWidth() - 40, 40);
+                    break;
+                case 3:
+                    v.setPosition(Gdx.graphics.getWidth() - 40,
+                        Gdx.graphics.getHeight() -40);
+                    break;
+                default:
+                    v.setPosition(Gdx.graphics.getWidth() - 40,
+                        Gdx.graphics.getHeight() -40);
+                    break;
+            }
+        }
+    }
+}

--- a/core/src/com/tds/screen/MenuScreen.java
+++ b/core/src/com/tds/screen/MenuScreen.java
@@ -1,0 +1,41 @@
+package com.tds.screen;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.tds.TDS;
+
+public class MenuScreen extends ScreenAdapter {
+    private final TDS game;
+    private BitmapFont font;
+
+    public MenuScreen(TDS game) {
+        this.game = game;
+    }
+
+    @Override
+    public void show() {
+        font = new BitmapFont();
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        game.batch.begin();
+        font.draw(game.batch, "Press ENTER to Start", 100, 100);
+        game.batch.end();
+
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
+            game.setScreen(new GameScreen(game));
+        }
+    }
+
+    @Override
+    public void dispose() {
+        font.dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `ApplicationAdapter` with `Game` subclass and central `AssetManager`
- Introduce `MenuScreen` and `GameScreen` to manage menus and gameplay
- Shift gameplay loop and level generation into `GameScreen`
- Expose bullet rendering and wall collision helpers in `Admin`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a3903952748325af773115e6fc5e28