### PR TITLE
Add central InputHandler and action mapping

### DIFF
--- a/core/src/com/tds/Admin.java
+++ b/core/src/com/tds/Admin.java
@@ -7,11 +7,12 @@
 package com.tds;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Circle;
 import com.badlogic.gdx.math.Rectangle;
+import com.tds.input.InputHandler;
+import com.tds.input.InputHandler.Action;
 import java.util.ArrayList;
 
 /**
@@ -66,29 +67,30 @@ public class Admin extends Entity{
         this.setOriginCenter();
         float mouseX = Gdx.input.getX();
         float mouseY = Gdx.graphics.getHeight() - Gdx.input.getY();
-        
+
+        InputHandler input = InputHandler.getInstance();
         boolean keyPressed = false;
-        if(Gdx.input.isKeyPressed(Input.Keys.A)){
+        if(input.isActionPressed(Action.MOVE_LEFT)){
             keyPressed = true;
             this.setX(this.getX() - Gdx.graphics.getDeltaTime() * getSpeed());
         }
-        if(Gdx.input.isKeyPressed(Input.Keys.D)) {
+        if(input.isActionPressed(Action.MOVE_RIGHT)) {
             keyPressed = true;
             this.setX(this.getX() + Gdx.graphics.getDeltaTime() * getSpeed());
         }
-        if(Gdx.input.isKeyPressed(Input.Keys.W)) {
+        if(input.isActionPressed(Action.MOVE_UP)) {
             keyPressed = true;
             this.setY(this.getY() + Gdx.graphics.getDeltaTime() * getSpeed());
         }
-        if(Gdx.input.isKeyPressed(Input.Keys.S)) {
+        if(input.isActionPressed(Action.MOVE_DOWN)) {
             keyPressed = true;
             this.setY(this.getY() - Gdx.graphics.getDeltaTime() * getSpeed());
         }
-        
+
         float dirX =  mouseX - getX() - getWidth()/2;
         float dirY =  mouseY - getY() - getHeight()/2;
         double angle = Math.atan2(-dirX, dirY);
-        if(Gdx.input.isButtonPressed(Input.Buttons.LEFT))
+        if(input.isActionPressed(Action.FIRE))
             bullets.shoot(4, 0.1f, (float)Math.toDegrees(angle), getX() + 100, getY() + 100, 20);
                 
         this.boundingCircle.setPosition(this.getX(), this.getY());

--- a/core/src/com/tds/input/InputHandler.java
+++ b/core/src/com/tds/input/InputHandler.java
@@ -1,0 +1,119 @@
+package com.tds.input;
+
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.InputAdapter;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Centralized input handler that maps high level actions to concrete keys or
+ * buttons. Consumers can query the state of an action or register callbacks
+ * that fire when an action is triggered.
+ */
+public class InputHandler extends InputAdapter {
+
+    /** High level actions available in the game. */
+    public enum Action {
+        MOVE_LEFT,
+        MOVE_RIGHT,
+        MOVE_UP,
+        MOVE_DOWN,
+        DASH,
+        FIRE
+    }
+
+    private static final InputHandler INSTANCE = new InputHandler();
+
+    private final Map<Action, Integer> bindings = new EnumMap<>(Action.class);
+    private final Map<Action, Boolean> states = new EnumMap<>(Action.class);
+    private final Map<Action, List<Runnable>> listeners = new EnumMap<>(Action.class);
+
+    private InputHandler() {
+        // Default bindings
+        bindings.put(Action.MOVE_LEFT, Input.Keys.A);
+        bindings.put(Action.MOVE_RIGHT, Input.Keys.D);
+        bindings.put(Action.MOVE_UP, Input.Keys.W);
+        bindings.put(Action.MOVE_DOWN, Input.Keys.S);
+        bindings.put(Action.DASH, Input.Keys.SHIFT_LEFT);
+        bindings.put(Action.FIRE, Input.Buttons.LEFT);
+
+        for (Action action : Action.values()) {
+            states.put(action, false);
+            listeners.put(action, new ArrayList<Runnable>());
+        }
+    }
+
+    /**
+     * @return global {@link InputHandler} instance.
+     */
+    public static InputHandler getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Binds an action to a specific key or button.
+     */
+    public void bind(Action action, int code) {
+        bindings.put(action, code);
+    }
+
+    /**
+     * Registers a callback to run when an action is triggered.
+     */
+    public void register(Action action, Runnable callback) {
+        listeners.get(action).add(callback);
+    }
+
+    /**
+     * Returns whether an action is currently active.
+     */
+    public boolean isActionPressed(Action action) {
+        Boolean value = states.get(action);
+        return value != null && value.booleanValue();
+    }
+
+    @Override
+    public boolean keyDown(int keycode) {
+        handlePress(keycode);
+        return false;
+    }
+
+    @Override
+    public boolean keyUp(int keycode) {
+        handleRelease(keycode);
+        return false;
+    }
+
+    @Override
+    public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+        handlePress(button);
+        return false;
+    }
+
+    @Override
+    public boolean touchUp(int screenX, int screenY, int pointer, int button) {
+        handleRelease(button);
+        return false;
+    }
+
+    private void handlePress(int code) {
+        for (Map.Entry<Action, Integer> entry : bindings.entrySet()) {
+            if (entry.getValue() == code) {
+                states.put(entry.getKey(), true);
+                for (Runnable r : listeners.get(entry.getKey())) {
+                    r.run();
+                }
+            }
+        }
+    }
+
+    private void handleRelease(int code) {
+        for (Map.Entry<Action, Integer> entry : bindings.entrySet()) {
+            if (entry.getValue() == code) {
+                states.put(entry.getKey(), false);
+            }
+        }
+    }
+}

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -12,6 +12,7 @@ import com.tds.HUD;
 import com.tds.TDS;
 import com.tds.Virus;
 import com.tds.Wall;
+import com.tds.input.InputHandler;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -52,6 +53,9 @@ public class GameScreen extends ScreenAdapter {
         pen.setColor(Color.YELLOW);
 
         walls = new Wall[4];
+
+        // Direct all input events to the centralized input handler
+        Gdx.input.setInputProcessor(InputHandler.getInstance());
         int gap = 200;
         int wallWidth = 50;
         int worldHeight = Gdx.graphics.getHeight();


### PR DESCRIPTION
## Summary
- Introduce `InputHandler` to map high-level actions to keys/buttons and allow action listeners
- Replace hard-coded key checks in `Admin` with action queries
- Route input through `InputHandler` in `GameScreen`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3953434e08325abbfb17f1ef6d347