### PR TITLE
Add persistent high score tracking

### DIFF
--- a/core/src/com/tds/HUD.java
+++ b/core/src/com/tds/HUD.java
@@ -17,9 +17,11 @@ public class HUD {
     private int totalScore;
     private int currentLevel;
     private int currentLives;
+    private int highScore;
     private final String level = "Level: ";
     private final String score = "Score: ";
     private final String lives = "Lives: ";
+    private final String highScoreLabel = "High Score: ";
     
     /**
      * @author KeisterBun
@@ -73,6 +75,7 @@ public class HUD {
         pen.draw(batch, score.concat(Integer.toString(totalScore)), 20, Gdx.graphics.getHeight()-20);
         pen.draw(batch, level.concat(Integer.toString(currentLevel)), 20, Gdx.graphics.getHeight()-40);
         pen.draw(batch, lives.concat(Integer.toString(currentLives)), 20, Gdx.graphics.getHeight()-60);
+        pen.draw(batch, highScoreLabel.concat(Integer.toString(highScore)), 20, Gdx.graphics.getHeight()-80);
     }
 
     public int getCurrentLives() {
@@ -81,6 +84,14 @@ public class HUD {
 
     public void setCurrentLives(int currentLives) {
         this.currentLives = currentLives;
+    }
+
+    public int getHighScore() {
+        return highScore;
+    }
+
+    public void setHighScore(int highScore) {
+        this.highScore = highScore;
     }
     
 }

--- a/core/src/com/tds/ScoreManager.java
+++ b/core/src/com/tds/ScoreManager.java
@@ -1,0 +1,49 @@
+package com.tds;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Preferences;
+
+/**
+ * Handles persistent storage of high scores.
+ */
+public final class ScoreManager {
+    private static final String PREFS_NAME = "com.tds.highscores";
+    private static final String KEY_HIGH_SCORE = "highScore";
+
+    private ScoreManager() {
+        // Utility class
+    }
+
+    /**
+     * Retrieve the stored high score.
+     *
+     * @return current high score or 0 if none stored
+     */
+    public static int getHighScore() {
+        Preferences prefs = Gdx.app.getPreferences(PREFS_NAME);
+        return prefs.getInteger(KEY_HIGH_SCORE, 0);
+    }
+
+    /**
+     * Submit a score. If the score is higher than the stored value it will be saved.
+     *
+     * @param score score to compare against the stored high score
+     */
+    public static void submitScore(int score) {
+        Preferences prefs = Gdx.app.getPreferences(PREFS_NAME);
+        int current = prefs.getInteger(KEY_HIGH_SCORE, 0);
+        if (score > current) {
+            prefs.putInteger(KEY_HIGH_SCORE, score);
+            prefs.flush();
+        }
+    }
+
+    /**
+     * Reset the high score. Intended for development and testing.
+     */
+    public static void reset() {
+        Preferences prefs = Gdx.app.getPreferences(PREFS_NAME);
+        prefs.putInteger(KEY_HIGH_SCORE, 0);
+        prefs.flush();
+    }
+}

--- a/core/src/com/tds/TDS.java
+++ b/core/src/com/tds/TDS.java
@@ -9,6 +9,7 @@ import com.tds.screen.MenuScreen;
 public class TDS extends Game {
     public SpriteBatch batch;
     public AssetManager assetManager;
+    private int highScore;
 
     @Override
     public void create () {
@@ -18,6 +19,9 @@ public class TDS extends Game {
         assetManager.load("background.png", Texture.class);
         assetManager.load("virus.png", Texture.class);
         assetManager.finishLoading();
+
+        // Retrieve any persisted high score on startup
+        highScore = ScoreManager.getHighScore();
         setScreen(new MenuScreen(this));
     }
 
@@ -26,5 +30,27 @@ public class TDS extends Game {
         super.dispose();
         batch.dispose();
         assetManager.dispose();
+    }
+
+    public int getHighScore() {
+        return highScore;
+    }
+
+    /**
+     * Submit a score and refresh the cached high score.
+     *
+     * @param score score to compare with the stored high score
+     */
+    public void submitScore(int score) {
+        ScoreManager.submitScore(score);
+        highScore = ScoreManager.getHighScore();
+    }
+
+    /**
+     * Reset the stored high score. Useful for testing.
+     */
+    public void resetHighScore() {
+        ScoreManager.reset();
+        highScore = 0;
     }
 }

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -36,6 +36,7 @@ public class GameScreen extends ScreenAdapter {
     @Override
     public void show() {
         hud = new HUD();
+        hud.setHighScore(game.getHighScore());
         background = game.assetManager.get("background.png", Texture.class);
         virusTexture = game.assetManager.get("virus.png", Texture.class);
 
@@ -127,6 +128,8 @@ public class GameScreen extends ScreenAdapter {
         }
 
         if(virusList.size() == 0){
+            game.submitScore(hud.getTotalScore());
+            hud.setHighScore(game.getHighScore());
             level += 1;
             hud.incrementCurrentLevel();
             generateLevel(level);


### PR DESCRIPTION
## Summary
- store and retrieve high scores via new `ScoreManager`
- show current high score in HUD and refresh after each level
- expose high score submit/reset methods in main game class

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3971ca3008325825dc5f5c2550770