### PR TITLE
Introduce camera-driven rendering with strategy interface

### DIFF
--- a/core/src/com/tds/Admin.java
+++ b/core/src/com/tds/Admin.java
@@ -13,6 +13,8 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Circle;
 import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.utils.viewport.Viewport;
 import com.tds.input.InputHandler;
 import com.tds.input.InputHandler.Action;
 import com.tds.assets.AnimationSet;
@@ -56,12 +58,13 @@ public class Admin extends Entity{
         this.lives = lives;
     }
     
-    public void processMovement(ArrayList<Virus> enemies){
+    public void processMovement(ArrayList<Virus> enemies, Viewport viewport){
         oldX = getX();
         oldY = getY();
         this.setOriginCenter();
-        float mouseX = Gdx.input.getX();
-        float mouseY = Gdx.graphics.getHeight() - Gdx.input.getY();
+        Vector3 mouseWorld = viewport.unproject(new Vector3(Gdx.input.getX(), Gdx.input.getY(), 0));
+        float mouseX = mouseWorld.x;
+        float mouseY = mouseWorld.y;
 
         InputHandler input = InputHandler.getInstance();
         boolean keyPressed = false;

--- a/core/src/com/tds/screen/OrthographicRenderStrategy.java
+++ b/core/src/com/tds/screen/OrthographicRenderStrategy.java
@@ -1,0 +1,44 @@
+package com.tds.screen;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
+
+/**
+ * Render strategy using a standard orthographic camera and fit viewport.
+ */
+public class OrthographicRenderStrategy implements RenderStrategy {
+
+    private final OrthographicCamera camera;
+    private final Viewport viewport;
+
+    public OrthographicRenderStrategy(float worldWidth, float worldHeight) {
+        camera = new OrthographicCamera();
+        viewport = new FitViewport(worldWidth, worldHeight, camera);
+        camera.position.set(worldWidth / 2f, worldHeight / 2f, 0f);
+    }
+
+    @Override
+    public Camera getCamera() {
+        return camera;
+    }
+
+    @Override
+    public Viewport getViewport() {
+        return viewport;
+    }
+
+    @Override
+    public void apply(SpriteBatch batch) {
+        camera.update();
+        batch.setProjectionMatrix(camera.combined);
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        viewport.update(width, height);
+    }
+}
+

--- a/core/src/com/tds/screen/RenderStrategy.java
+++ b/core/src/com/tds/screen/RenderStrategy.java
@@ -1,0 +1,36 @@
+package com.tds.screen;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.utils.viewport.Viewport;
+
+/**
+ * Strategy interface for configuring render state.
+ */
+public interface RenderStrategy {
+    /**
+     * @return camera used for rendering
+     */
+    Camera getCamera();
+
+    /**
+     * @return viewport controlling the camera
+     */
+    Viewport getViewport();
+
+    /**
+     * Update the camera and apply its projection to the batch.
+     *
+     * @param batch sprite batch to configure
+     */
+    void apply(SpriteBatch batch);
+
+    /**
+     * Update the viewport on window resize.
+     *
+     * @param width  new viewport width
+     * @param height new viewport height
+     */
+    void resize(int width, int height);
+}
+


### PR DESCRIPTION
## Summary
- Add `OrthographicCamera` and `Viewport` to `GameScreen`
- Render using camera combined matrix via a new `RenderStrategy`
- Use viewport world dimensions for entity placement and movement

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a39bd33b4083258e7162c0e40e31f1