### PR TITLE
Fix camera zoom and sprite sizes

### DIFF
--- a/core/src/com/tds/Admin.java
+++ b/core/src/com/tds/Admin.java
@@ -42,7 +42,7 @@ public class Admin extends Entity{
                 animations.getDown().getKeyFrame(0).getRegionHeight());
 
         setRegion(animations.getDown().getKeyFrame(0));
-        setScale(0.25f);
+        setScale(1f);
 
         this.lives = lives;
         this.animations = animations;

--- a/core/src/com/tds/Virus.java
+++ b/core/src/com/tds/Virus.java
@@ -20,8 +20,8 @@ public class Virus extends Entity{
     public Virus(Texture texture, int level) {
         super(1, 200, texture, 0, 0, 128, 128);
         Random rand = new Random();
-        speed = 200 + level*20 + (rand.nextInt()%60 - 30);        
-        setScale(0.75f);
+        speed = 200 + level*20 + (rand.nextInt()%60 - 30);
+        setScale(1f);
         setHealth((int)Math.log10(level) + 1);
 
         alive = true;

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -22,9 +22,6 @@ import java.util.ArrayList;
 import java.util.Random;
 
 public class GameScreen extends ScreenAdapter {
-    private static final float WORLD_WIDTH = 800f;
-    private static final float WORLD_HEIGHT = 480f;
-
     private final TDS game;
     private HUD hud;
     private Admin admin;
@@ -42,7 +39,11 @@ public class GameScreen extends ScreenAdapter {
 
     public GameScreen(TDS game) {
         this.game = game;
-        renderStrategy = new OrthographicRenderStrategy(WORLD_WIDTH, WORLD_HEIGHT);
+
+        float worldWidth = Gdx.graphics.getWidth();
+        float worldHeight = Gdx.graphics.getHeight();
+
+        renderStrategy = new OrthographicRenderStrategy(worldWidth, worldHeight);
         camera = (OrthographicCamera) renderStrategy.getCamera();
         viewport = renderStrategy.getViewport();
     }
@@ -59,7 +60,6 @@ public class GameScreen extends ScreenAdapter {
         float posx = viewport.getWorldWidth()/2 - admin.getWidth()/2;
         float posy = viewport.getWorldHeight()/2 - admin.getHeight()/2;
         admin.setPosition(posx, posy);
-        admin.scale(.2f);
 
         virusList = new ArrayList<Virus>();
         level = 1;


### PR DESCRIPTION
## Summary
- Derive viewport dimensions from the current screen size to avoid an overly zoomed view.
- Display player and virus sprites at full scale for proper on-screen size.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a39df795cc83259c6318b8a49449e1