### PR TITLE
Inject configurable InputService and support unit testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,15 @@ project(":desktop") {
     }
 }
 
-project(":core") {
-    apply plugin: "java"
+    project(":core") {
+        apply plugin: "java"
 
 
-    dependencies {
-        implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
-        implementation "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
-        testImplementation "junit:junit:4.13.2"
+        dependencies {
+            implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
+            implementation "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
+            testImplementation "junit:junit:4.13.2"
+            testImplementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
+            testRuntimeOnly "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+        }
     }
-}

--- a/core/src/com/tds/Admin.java
+++ b/core/src/com/tds/Admin.java
@@ -15,8 +15,8 @@ import com.badlogic.gdx.math.Circle;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.Viewport;
-import com.tds.input.InputHandler;
-import com.tds.input.InputHandler.Action;
+import com.tds.input.InputService;
+import com.tds.input.InputService.Action;
 import com.tds.assets.AnimationSet;
 import java.util.ArrayList;
 
@@ -31,9 +31,15 @@ public class Admin extends Entity{
     float oldX, oldY;
 
     private final AnimationSet animations;
+    private final InputService input;
 
     public Admin(float strength, int lives, float health, float speed,
-            AnimationSet animations) {
+            AnimationSet animations, InputService input) {
+        this(strength, lives, health, speed, animations, input, new Texture("Bullet.png"));
+    }
+
+    public Admin(float strength, int lives, float health, float speed,
+            AnimationSet animations, InputService input, Texture bulletTexture) {
         super(health, speed,
                 animations.getDown().getKeyFrame(0).getTexture(),
                 animations.getDown().getKeyFrame(0).getRegionX(),
@@ -46,7 +52,8 @@ public class Admin extends Entity{
 
         this.lives = lives;
         this.animations = animations;
-        bullets = new ParticleSystem(new Texture("Bullet.png"));
+        bullets = new ParticleSystem(bulletTexture);
+        this.input = input;
     }
 
     
@@ -66,7 +73,6 @@ public class Admin extends Entity{
         float mouseX = mouseWorld.x;
         float mouseY = mouseWorld.y;
 
-        InputHandler input = InputHandler.getInstance();
         boolean keyPressed = false;
         if(input.isActionPressed(Action.MOVE_LEFT)){
             keyPressed = true;

--- a/core/src/com/tds/TDS.java
+++ b/core/src/com/tds/TDS.java
@@ -7,19 +7,31 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.tds.score.GdxPreferencesScoreRepository;
 import com.tds.score.ScoreRepository;
 import com.tds.screen.MenuScreen;
+import com.tds.input.InputService;
+import com.tds.input.InputHandler;
 
 public class TDS extends Game {
     public SpriteBatch batch;
     public AssetManager assetManager;
     private int highScore;
     private final ScoreRepository scoreRepository;
+    private final InputService inputService;
 
     public TDS() {
-        this(new GdxPreferencesScoreRepository());
+        this(new InputHandler(), new GdxPreferencesScoreRepository());
     }
 
     public TDS(ScoreRepository scoreRepository) {
+        this(new InputHandler(), scoreRepository);
+    }
+
+    public TDS(InputService inputService) {
+        this(inputService, new GdxPreferencesScoreRepository());
+    }
+
+    public TDS(InputService inputService, ScoreRepository scoreRepository) {
         this.scoreRepository = scoreRepository;
+        this.inputService = inputService;
     }
 
     @Override
@@ -32,7 +44,7 @@ public class TDS extends Game {
 
         // Retrieve any persisted high score on startup
         highScore = scoreRepository.getHighScore();
-        setScreen(new MenuScreen(this));
+        setScreen(new MenuScreen(this, inputService));
     }
 
     @Override

--- a/core/src/com/tds/input/InputHandler.java
+++ b/core/src/com/tds/input/InputHandler.java
@@ -8,29 +8,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Centralized input handler that maps high level actions to concrete keys or
- * buttons. Consumers can query the state of an action or register callbacks
- * that fire when an action is triggered.
+ * Concrete {@link InputService} implementation backed by LibGDX input APIs.
  */
-public class InputHandler extends InputAdapter {
-
-    /** High level actions available in the game. */
-    public enum Action {
-        MOVE_LEFT,
-        MOVE_RIGHT,
-        MOVE_UP,
-        MOVE_DOWN,
-        DASH,
-        FIRE
-    }
-
-    private static final InputHandler INSTANCE = new InputHandler();
+public class InputHandler extends InputAdapter implements InputService {
 
     private final Map<Action, Integer> bindings = new EnumMap<>(Action.class);
     private final Map<Action, Boolean> states = new EnumMap<>(Action.class);
     private final Map<Action, List<Runnable>> listeners = new EnumMap<>(Action.class);
 
-    private InputHandler() {
+    public InputHandler() {
         // Default bindings
         bindings.put(Action.MOVE_LEFT, Input.Keys.A);
         bindings.put(Action.MOVE_RIGHT, Input.Keys.D);
@@ -45,30 +31,17 @@ public class InputHandler extends InputAdapter {
         }
     }
 
-    /**
-     * @return global {@link InputHandler} instance.
-     */
-    public static InputHandler getInstance() {
-        return INSTANCE;
-    }
-
-    /**
-     * Binds an action to a specific key or button.
-     */
+    @Override
     public void bind(Action action, int code) {
         bindings.put(action, code);
     }
 
-    /**
-     * Registers a callback to run when an action is triggered.
-     */
+    @Override
     public void register(Action action, Runnable callback) {
         listeners.get(action).add(callback);
     }
 
-    /**
-     * Returns whether an action is currently active.
-     */
+    @Override
     public boolean isActionPressed(Action action) {
         Boolean value = states.get(action);
         return value != null && value.booleanValue();

--- a/core/src/com/tds/input/InputService.java
+++ b/core/src/com/tds/input/InputService.java
@@ -1,0 +1,34 @@
+package com.tds.input;
+
+import com.badlogic.gdx.InputProcessor;
+
+/**
+ * Service interface for querying and configuring input actions.
+ */
+public interface InputService extends InputProcessor {
+
+    /** High level actions available in the game. */
+    enum Action {
+        MOVE_LEFT,
+        MOVE_RIGHT,
+        MOVE_UP,
+        MOVE_DOWN,
+        DASH,
+        FIRE
+    }
+
+    /**
+     * Returns whether the given action is currently pressed.
+     */
+    boolean isActionPressed(Action action);
+
+    /**
+     * Registers a callback to run when an action is triggered.
+     */
+    void register(Action action, Runnable callback);
+
+    /**
+     * Binds an action to a specific key or button code.
+     */
+    void bind(Action action, int code);
+}

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -16,7 +16,7 @@ import com.tds.HUD;
 import com.tds.TDS;
 import com.tds.Virus;
 import com.tds.Wall;
-import com.tds.input.InputHandler;
+import com.tds.input.InputService;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -36,9 +36,11 @@ public class GameScreen extends ScreenAdapter {
     private final OrthographicCamera camera;
     private final Viewport viewport;
     private final RenderStrategy renderStrategy;
+    private final InputService input;
 
-    public GameScreen(TDS game) {
+    public GameScreen(TDS game, InputService input) {
         this.game = game;
+        this.input = input;
 
         float worldWidth = Gdx.graphics.getWidth();
         float worldHeight = Gdx.graphics.getHeight();
@@ -56,7 +58,7 @@ public class GameScreen extends ScreenAdapter {
         virusTexture = game.assetManager.get("virus.png", Texture.class);
 
         AnimationSet animations = AnimationSetFactory.load(game.assetManager, "playerModel.json");
-        admin = new Admin(1, 3, 1, 300, animations);
+        admin = new Admin(1, 3, 1, 300, animations, input);
         float posx = viewport.getWorldWidth()/2 - admin.getWidth()/2;
         float posy = viewport.getWorldHeight()/2 - admin.getHeight()/2;
         admin.setPosition(posx, posy);
@@ -71,7 +73,7 @@ public class GameScreen extends ScreenAdapter {
         walls = new Wall[4];
 
         // Direct all input events to the centralized input handler
-        Gdx.input.setInputProcessor(InputHandler.getInstance());
+        Gdx.input.setInputProcessor(input);
         int gap = 200;
         int wallWidth = 50;
         float worldHeight = viewport.getWorldHeight();

--- a/core/src/com/tds/screen/MenuScreen.java
+++ b/core/src/com/tds/screen/MenuScreen.java
@@ -6,13 +6,16 @@ import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.tds.TDS;
+import com.tds.input.InputService;
 
 public class MenuScreen extends ScreenAdapter {
     private final TDS game;
+    private final InputService input;
     private BitmapFont font;
 
-    public MenuScreen(TDS game) {
+    public MenuScreen(TDS game, InputService input) {
         this.game = game;
+        this.input = input;
     }
 
     @Override
@@ -30,7 +33,7 @@ public class MenuScreen extends ScreenAdapter {
         game.batch.end();
 
         if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
-            game.setScreen(new GameScreen(game));
+            game.setScreen(new GameScreen(game, input));
         }
     }
 

--- a/core/test/com/tds/input/AdminInputServiceTest.java
+++ b/core/test/com/tds/input/AdminInputServiceTest.java
@@ -1,0 +1,161 @@
+package com.tds.input;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+import com.badlogic.gdx.backends.headless.mock.graphics.MockGraphics;
+import com.badlogic.gdx.backends.headless.mock.input.MockInput;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Animation;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.tds.Admin;
+import com.tds.Virus;
+import com.tds.assets.AnimationSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+import com.tds.input.InputService.Action;
+
+/**
+ * Verifies that {@link Admin#processMovement(java.util.ArrayList, com.badlogic.gdx.utils.viewport.Viewport)}
+ * reacts to input provided via {@link InputService}.
+ */
+public class AdminInputServiceTest {
+
+    private static class StubInputService extends com.badlogic.gdx.InputAdapter implements InputService {
+        private final EnumSet<Action> pressed = EnumSet.noneOf(Action.class);
+
+        @Override
+        public boolean isActionPressed(Action action) {
+            return pressed.contains(action);
+        }
+
+        @Override
+        public void register(Action action, Runnable callback) {
+            // no-op
+        }
+
+        @Override
+        public void bind(Action action, int code) {
+            // no-op
+        }
+    }
+
+    @Before
+    public void setup() {
+        if (Gdx.app == null) {
+            HeadlessApplicationConfiguration config = new HeadlessApplicationConfiguration();
+            new HeadlessApplication(new ApplicationAdapter(){}, config);
+        }
+        Gdx.graphics = new MockGraphics() {
+            @Override
+            public float getDeltaTime() { return 1f; }
+        };
+        Gdx.input = new MockInput();
+        Gdx.files = new TestFiles();
+    }
+
+    private AnimationSet createAnimations() {
+        Texture texture = new DummyTexture();
+        TextureRegion region = new TextureRegion(texture, 1, 1);
+        Animation<TextureRegion> anim = new Animation<>(0.1f, region);
+        return new AnimationSet(anim, anim, anim, anim);
+    }
+
+    private static class DummyTexture extends com.badlogic.gdx.graphics.Texture {
+        public DummyTexture() { super(); }
+
+        @Override
+        public int getWidth() { return 1; }
+
+        @Override
+        public int getHeight() { return 1; }
+
+        @Override
+        public int getDepth() { return 0; }
+
+        @Override
+        public com.badlogic.gdx.graphics.TextureData getTextureData() { return null; }
+
+        @Override
+        public boolean isManaged() { return false; }
+
+        @Override
+        protected void reload() { }
+    }
+
+    private static class TestFiles implements Files {
+        @Override
+        public FileHandle getFileHandle(String fileName, FileType type) {
+            return new FileHandle(fileName);
+        }
+
+        @Override
+        public FileHandle classpath(String path) {
+            return new FileHandle(path);
+        }
+
+        @Override
+        public FileHandle internal(String path) {
+            return new FileHandle("core/assets/" + path);
+        }
+
+        @Override
+        public FileHandle external(String path) {
+            return new FileHandle(path);
+        }
+
+        @Override
+        public FileHandle absolute(String path) {
+            return new FileHandle(path);
+        }
+
+        @Override
+        public FileHandle local(String path) {
+            return new FileHandle(path);
+        }
+
+        @Override
+        public String getExternalStoragePath() {
+            return "";
+        }
+
+        @Override
+        public boolean isExternalStorageAvailable() {
+            return false;
+        }
+
+        @Override
+        public String getLocalStoragePath() {
+            return "";
+        }
+
+        @Override
+        public boolean isLocalStorageAvailable() {
+            return true;
+        }
+    }
+
+    @Test
+    public void movesLeftWhenActionPressed() {
+        StubInputService input = new StubInputService();
+        input.pressed.add(Action.MOVE_LEFT);
+        Admin admin = new Admin(1, 3, 1, 10, createAnimations(), input, new DummyTexture());
+        ScreenViewport viewport = new ScreenViewport(new OrthographicCamera());
+        viewport.setWorldSize(100, 100);
+        viewport.getCamera().position.set(0,0,0);
+        viewport.getCamera().update();
+        admin.setPosition(5, 0);
+        admin.processMovement(new ArrayList<Virus>(), viewport);
+        assertEquals(-5f, admin.getX(), 0.001f);
+    }
+}

--- a/desktop/src/com/tds/desktop/DesktopLauncher.java
+++ b/desktop/src/com/tds/desktop/DesktopLauncher.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.tds.TDS;
+import com.tds.input.InputHandler;
 
 
 public class DesktopLauncher {
@@ -11,6 +12,7 @@ public class DesktopLauncher {
                 Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
                 DisplayMode displayMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
                 config.setFullscreenMode(displayMode);
-                new Lwjgl3Application(new TDS(), config);
+                InputHandler input = new InputHandler();
+                new Lwjgl3Application(new TDS(input), config);
         }
 }


### PR DESCRIPTION
## Summary
- Add `InputService` interface and implement it in `InputHandler`
- Inject `InputService` into `Admin`, `GameScreen`, and menu/game bootstrap
- Provide test ensuring `Admin.processMovement` reacts to injected input

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a3a3c7060483259098295ce729d157