### PR TITLE
Introduce graphics context abstraction for rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,7 @@ This project contains unit tests. Run them with:
 ```
 ./gradlew test
 ```
+
+## Development
+- Avoid direct calls to `Gdx.graphics`. Use the `GraphicsContext` interface and inject implementations where needed.
+- Tests that require graphics timing or sizing should prefer `FakeGraphicsContext` from the `core/test` package.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Verify with:
 ./gradlew desktop:run
 ```
 
+## Development
+Game code that needs frame timing or screen dimensions should depend on the `GraphicsContext` interface rather than accessing `Gdx.graphics` directly. The `core` module provides a `GdxGraphicsContext` implementation and tests can use `FakeGraphicsContext` to control values.
+
 ## macOS notes
 - Ensure the Gradle wrapper is executable:
 

--- a/core/src/com/tds/Admin.java
+++ b/core/src/com/tds/Admin.java
@@ -18,6 +18,7 @@ import com.badlogic.gdx.utils.viewport.Viewport;
 import com.tds.input.InputService;
 import com.tds.input.InputService.Action;
 import com.tds.assets.AnimationSet;
+import com.tds.platform.GraphicsContext;
 import java.util.ArrayList;
 
 /**
@@ -30,16 +31,18 @@ public class Admin extends Entity{
     float stateTime = 0;
     float oldX, oldY;
 
+    private final GraphicsContext graphics;
+
     private final AnimationSet animations;
     private final InputService input;
 
     public Admin(float strength, int lives, float health, float speed,
-            AnimationSet animations, InputService input) {
-        this(strength, lives, health, speed, animations, input, new Texture("Bullet.png"));
+            AnimationSet animations, InputService input, GraphicsContext graphics) {
+        this(strength, lives, health, speed, animations, input, new Texture("Bullet.png"), graphics);
     }
 
     public Admin(float strength, int lives, float health, float speed,
-            AnimationSet animations, InputService input, Texture bulletTexture) {
+            AnimationSet animations, InputService input, Texture bulletTexture, GraphicsContext graphics) {
         super(health, speed,
                 animations.getDown().getKeyFrame(0).getTexture(),
                 animations.getDown().getKeyFrame(0).getRegionX(),
@@ -52,8 +55,9 @@ public class Admin extends Entity{
 
         this.lives = lives;
         this.animations = animations;
-        bullets = new ParticleSystem(bulletTexture);
+        bullets = new ParticleSystem(bulletTexture, graphics);
         this.input = input;
+        this.graphics = graphics;
     }
 
     
@@ -76,19 +80,19 @@ public class Admin extends Entity{
         boolean keyPressed = false;
         if(input.isActionPressed(Action.MOVE_LEFT)){
             keyPressed = true;
-            this.setX(this.getX() - Gdx.graphics.getDeltaTime() * getSpeed());
+            this.setX(this.getX() - graphics.getDeltaTime() * getSpeed());
         }
         if(input.isActionPressed(Action.MOVE_RIGHT)) {
             keyPressed = true;
-            this.setX(this.getX() + Gdx.graphics.getDeltaTime() * getSpeed());
+            this.setX(this.getX() + graphics.getDeltaTime() * getSpeed());
         }
         if(input.isActionPressed(Action.MOVE_UP)) {
             keyPressed = true;
-            this.setY(this.getY() + Gdx.graphics.getDeltaTime() * getSpeed());
+            this.setY(this.getY() + graphics.getDeltaTime() * getSpeed());
         }
         if(input.isActionPressed(Action.MOVE_DOWN)) {
             keyPressed = true;
-            this.setY(this.getY() - Gdx.graphics.getDeltaTime() * getSpeed());
+            this.setY(this.getY() - graphics.getDeltaTime() * getSpeed());
         }
 
         float dirX =  mouseX - getX() - getWidth()/2;
@@ -100,7 +104,7 @@ public class Admin extends Entity{
         this.boundingCircle.setPosition(this.getX(), this.getY());
 
         if(keyPressed) {
-            stateTime += Gdx.graphics.getDeltaTime();
+            stateTime += graphics.getDeltaTime();
         } else {
             stateTime = 0;
         }

--- a/core/src/com/tds/HUD.java
+++ b/core/src/com/tds/HUD.java
@@ -5,9 +5,9 @@
  */
 package com.tds;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.tds.platform.GraphicsContext;
 
 /**
  *
@@ -22,11 +22,13 @@ public class HUD {
     private final String score = "Score: ";
     private final String lives = "Lives: ";
     private final String highScoreLabel = "High Score: ";
+    private final GraphicsContext graphics;
     
     /**
      * @author KeisterBun
      */
-    public HUD() {
+    public HUD(GraphicsContext graphics) {
+        this.graphics = graphics;
         totalScore = 0;
         currentLevel = 1;
     }
@@ -61,9 +63,9 @@ public class HUD {
         totalScore = newTotal;
     }
     
-    public void gameOver(SpriteBatch batch, BitmapFont pen) {
-        pen.draw(batch, "GAME OVER", Gdx.graphics.getHeight()/2, Gdx.graphics.getWidth()/2);
-        
+    public void gameOver(Batch batch, BitmapFont pen) {
+        pen.draw(batch, "GAME OVER", graphics.getHeight()/2f, graphics.getWidth()/2f);
+
     }
     
     /**
@@ -71,11 +73,11 @@ public class HUD {
      * @param batch
      * @param pen 
      */
-    public void drawHud(SpriteBatch batch, BitmapFont pen) {
-        pen.draw(batch, score.concat(Integer.toString(totalScore)), 20, Gdx.graphics.getHeight()-20);
-        pen.draw(batch, level.concat(Integer.toString(currentLevel)), 20, Gdx.graphics.getHeight()-40);
-        pen.draw(batch, lives.concat(Integer.toString(currentLives)), 20, Gdx.graphics.getHeight()-60);
-        pen.draw(batch, highScoreLabel.concat(Integer.toString(highScore)), 20, Gdx.graphics.getHeight()-80);
+    public void drawHud(Batch batch, BitmapFont pen) {
+        pen.draw(batch, score.concat(Integer.toString(totalScore)), 20, graphics.getHeight()-20);
+        pen.draw(batch, level.concat(Integer.toString(currentLevel)), 20, graphics.getHeight()-40);
+        pen.draw(batch, lives.concat(Integer.toString(currentLives)), 20, graphics.getHeight()-60);
+        pen.draw(batch, highScoreLabel.concat(Integer.toString(highScore)), 20, graphics.getHeight()-80);
     }
 
     public int getCurrentLives() {

--- a/core/src/com/tds/ParticleSystem.java
+++ b/core/src/com/tds/ParticleSystem.java
@@ -5,10 +5,10 @@
  */
 package com.tds;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import java.util.ArrayList;
+import com.tds.platform.GraphicsContext;
 
 /**
  *
@@ -19,9 +19,11 @@ public class ParticleSystem {
     float rateTimer = 0;
     Texture texture;
     ArrayList<Entity> particles = new ArrayList<Entity>();
-    
-    public ParticleSystem(Texture pTex) {
+    private final GraphicsContext graphics;
+
+    public ParticleSystem(Texture pTex, GraphicsContext graphics) {
         texture = pTex;
+        this.graphics = graphics;
     }
     
     void shoot(float secondsOfLife, float fireRate, float angle, float x, float y, float speed) {
@@ -39,7 +41,7 @@ public class ParticleSystem {
     }
     
     void process(ArrayList<Virus> enemies) {
-        float time = Gdx.graphics.getDeltaTime();
+        float time = graphics.getDeltaTime();
         rateTimer += time;
         for(int i = particles.size() - 1; i >= 0; i--) {
             particles.get(i).translate(particles.get(i).vx, particles.get(i).vy);

--- a/core/src/com/tds/Virus.java
+++ b/core/src/com/tds/Virus.java
@@ -5,9 +5,9 @@
  */
 package com.tds;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import java.util.Random;
+import com.tds.platform.GraphicsContext;
 
 /**
  *
@@ -16,24 +16,28 @@ import java.util.Random;
 public class Virus extends Entity{
 
     boolean alive;
+    private final GraphicsContext graphics;
 
-    public Virus(Texture texture, int level) {
+    public Virus(Texture texture, int level, GraphicsContext graphics) {
         super(1, 200, texture, 0, 0, 128, 128);
         Random rand = new Random();
         speed = 200 + level*20 + (rand.nextInt()%60 - 30);
         setScale(1f);
         setHealth((int)Math.log10(level) + 1);
 
+        this.graphics = graphics;
+
         alive = true;
         //setX(100);
         //setY(100);        
     }
     
-    public Virus(Texture texture, float speed, int startx, int starty ) {
+    public Virus(Texture texture, float speed, int startx, int starty, GraphicsContext graphics ) {
         super(1, speed, texture, 0, 0, 32, 32);
         setX(startx);
         setY(starty);
         alive = true;
+        this.graphics = graphics;
     }
     
     /**
@@ -47,8 +51,8 @@ public class Virus extends Entity{
         double angle = Math.atan2(-dirX, dirY);
         float x, y;
         
-        x = (float)Math.cos(angle + Math.PI / 2) * getSpeed() * Gdx.graphics.getDeltaTime();
-        y = (float)Math.sin(angle + Math.PI / 2) * getSpeed() * Gdx.graphics.getDeltaTime();
+        x = (float)Math.cos(angle + Math.PI / 2) * getSpeed() * graphics.getDeltaTime();
+        y = (float)Math.sin(angle + Math.PI / 2) * getSpeed() * graphics.getDeltaTime();
         this.translate(x, y);
     }
     

--- a/core/src/com/tds/platform/GdxGraphicsContext.java
+++ b/core/src/com/tds/platform/GdxGraphicsContext.java
@@ -1,0 +1,20 @@
+package com.tds.platform;
+
+import com.badlogic.gdx.Gdx;
+
+public class GdxGraphicsContext implements GraphicsContext {
+    @Override
+    public float getDeltaTime() {
+        return Gdx.graphics.getDeltaTime();
+    }
+
+    @Override
+    public int getWidth() {
+        return Gdx.graphics.getWidth();
+    }
+
+    @Override
+    public int getHeight() {
+        return Gdx.graphics.getHeight();
+    }
+}

--- a/core/src/com/tds/platform/GraphicsContext.java
+++ b/core/src/com/tds/platform/GraphicsContext.java
@@ -1,0 +1,7 @@
+package com.tds.platform;
+
+public interface GraphicsContext {
+    float getDeltaTime();
+    int getWidth();
+    int getHeight();
+}

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -17,6 +17,8 @@ import com.tds.TDS;
 import com.tds.Virus;
 import com.tds.Wall;
 import com.tds.input.InputService;
+import com.tds.platform.GraphicsContext;
+import com.tds.platform.GdxGraphicsContext;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -37,13 +39,15 @@ public class GameScreen extends ScreenAdapter {
     private final Viewport viewport;
     private final RenderStrategy renderStrategy;
     private final InputService input;
+    private final GraphicsContext graphics;
 
     public GameScreen(TDS game, InputService input) {
         this.game = game;
         this.input = input;
 
-        float worldWidth = Gdx.graphics.getWidth();
-        float worldHeight = Gdx.graphics.getHeight();
+        this.graphics = new GdxGraphicsContext();
+        float worldWidth = graphics.getWidth();
+        float worldHeight = graphics.getHeight();
 
         renderStrategy = new OrthographicRenderStrategy(worldWidth, worldHeight);
         camera = (OrthographicCamera) renderStrategy.getCamera();
@@ -52,13 +56,13 @@ public class GameScreen extends ScreenAdapter {
 
     @Override
     public void show() {
-        hud = new HUD();
+        hud = new HUD(graphics);
         hud.setHighScore(game.getHighScore());
         background = game.assetManager.get("background.png", Texture.class);
         virusTexture = game.assetManager.get("virus.png", Texture.class);
 
         AnimationSet animations = AnimationSetFactory.load(game.assetManager, "playerModel.json");
-        admin = new Admin(1, 3, 1, 300, animations, input);
+        admin = new Admin(1, 3, 1, 300, animations, input, graphics);
         float posx = viewport.getWorldWidth()/2 - admin.getWidth()/2;
         float posy = viewport.getWorldHeight()/2 - admin.getHeight()/2;
         admin.setPosition(posx, posy);
@@ -162,7 +166,7 @@ public class GameScreen extends ScreenAdapter {
     void generateLevel(int levelNumber){
         int numberVirus = levelNumber*2 + levelNumber;
         for(int i = 0; i < numberVirus; i++) {
-            v1 = new Virus(virusTexture, levelNumber);
+            v1 = new Virus(virusTexture, levelNumber, graphics);
             virusList.add(v1);
         }
         Random rand = new Random();

--- a/core/test/com/tds/HUDDrawHudTest.java
+++ b/core/test/com/tds/HUDDrawHudTest.java
@@ -1,0 +1,62 @@
+package com.tds;
+
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+import com.tds.platform.FakeGraphicsContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HUDDrawHudTest {
+    private static class RecordingFont extends BitmapFont {
+        final java.util.List<Float> ys = new java.util.ArrayList<>();
+        RecordingFont() {
+            super(new BitmapFontData(), new TextureRegion(new DummyTexture()), false);
+        }
+        @Override
+        public com.badlogic.gdx.graphics.g2d.GlyphLayout draw(Batch batch, CharSequence str, float x, float y) {
+            ys.add(y);
+            return null;
+        }
+    }
+
+    private static class DummyTexture extends com.badlogic.gdx.graphics.Texture {
+        public DummyTexture() { super(); }
+        @Override public int getWidth() { return 1; }
+        @Override public int getHeight() { return 1; }
+        @Override public int getDepth() { return 0; }
+        @Override public com.badlogic.gdx.graphics.TextureData getTextureData() { return null; }
+        @Override public boolean isManaged() { return false; }
+        @Override protected void reload() { }
+    }
+
+    @Before
+    public void setup() {
+        if (Gdx.app == null) {
+            HeadlessApplicationConfiguration config = new HeadlessApplicationConfiguration();
+            new HeadlessApplication(new ApplicationAdapter(){}, config);
+        }
+    }
+
+    @Test
+    public void positionsHudRelativeToScreenHeight() {
+        FakeGraphicsContext graphics = new FakeGraphicsContext();
+        graphics.setSize(800, 600);
+        HUD hud = new HUD(graphics);
+        RecordingFont font = new RecordingFont();
+        hud.drawHud(null, font);
+        assertEquals(4, font.ys.size());
+        assertEquals(580f, font.ys.get(0), 0.001f);
+        assertEquals(560f, font.ys.get(1), 0.001f);
+        assertEquals(540f, font.ys.get(2), 0.001f);
+        assertEquals(520f, font.ys.get(3), 0.001f);
+        font.dispose();
+    }
+}

--- a/core/test/com/tds/HUDTest.java
+++ b/core/test/com/tds/HUDTest.java
@@ -2,11 +2,12 @@ package com.tds;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
+import com.tds.platform.FakeGraphicsContext;
 
 public class HUDTest {
     @Test
     public void testIncrementCurrentLevel() {
-        HUD hud = new HUD();
+        HUD hud = new HUD(new FakeGraphicsContext());
         int level = hud.getCurrentLevel();
         hud.incrementCurrentLevel();
         assertEquals(level + 1, hud.getCurrentLevel());
@@ -14,7 +15,7 @@ public class HUDTest {
 
     @Test
     public void testSetTotalScore() {
-        HUD hud = new HUD();
+        HUD hud = new HUD(new FakeGraphicsContext());
         hud.setTotalScore(42);
         assertEquals(42, hud.getTotalScore());
     }

--- a/core/test/com/tds/ParticleSystemTest.java
+++ b/core/test/com/tds/ParticleSystemTest.java
@@ -1,0 +1,30 @@
+package com.tds;
+
+import com.tds.platform.FakeGraphicsContext;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.ArrayList;
+
+public class ParticleSystemTest {
+    private static class DummyTexture extends com.badlogic.gdx.graphics.Texture {
+        public DummyTexture() { super(); }
+        @Override public int getWidth() { return 1; }
+        @Override public int getHeight() { return 1; }
+        @Override public int getDepth() { return 0; }
+        @Override public com.badlogic.gdx.graphics.TextureData getTextureData() { return null; }
+        @Override public boolean isManaged() { return false; }
+        @Override protected void reload() { }
+    }
+
+    @Test
+    public void removesParticlesWhenLifeExpires() {
+        FakeGraphicsContext graphics = new FakeGraphicsContext();
+        graphics.setDeltaTime(1f);
+        ParticleSystem system = new ParticleSystem(new DummyTexture(), graphics);
+        system.process(new ArrayList<Virus>());
+        system.shoot(1f, 0.5f, 0f, 0f, 0f, 0f);
+        assertEquals(1, system.particles.size());
+        system.process(new ArrayList<Virus>());
+        assertEquals(0, system.particles.size());
+    }
+}

--- a/core/test/com/tds/input/AdminInputServiceTest.java
+++ b/core/test/com/tds/input/AdminInputServiceTest.java
@@ -3,7 +3,6 @@ package com.tds.input;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.headless.HeadlessApplication;
 import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
-import com.badlogic.gdx.backends.headless.mock.graphics.MockGraphics;
 import com.badlogic.gdx.backends.headless.mock.input.MockInput;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.Files;
@@ -16,6 +15,7 @@ import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.tds.Admin;
 import com.tds.Virus;
 import com.tds.assets.AnimationSet;
+import com.tds.platform.FakeGraphicsContext;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,10 +56,6 @@ public class AdminInputServiceTest {
             HeadlessApplicationConfiguration config = new HeadlessApplicationConfiguration();
             new HeadlessApplication(new ApplicationAdapter(){}, config);
         }
-        Gdx.graphics = new MockGraphics() {
-            @Override
-            public float getDeltaTime() { return 1f; }
-        };
         Gdx.input = new MockInput();
         Gdx.files = new TestFiles();
     }
@@ -149,7 +145,9 @@ public class AdminInputServiceTest {
     public void movesLeftWhenActionPressed() {
         StubInputService input = new StubInputService();
         input.pressed.add(Action.MOVE_LEFT);
-        Admin admin = new Admin(1, 3, 1, 10, createAnimations(), input, new DummyTexture());
+        FakeGraphicsContext graphics = new FakeGraphicsContext();
+        graphics.setDeltaTime(1f);
+        Admin admin = new Admin(1, 3, 1, 10, createAnimations(), input, new DummyTexture(), graphics);
         ScreenViewport viewport = new ScreenViewport(new OrthographicCamera());
         viewport.setWorldSize(100, 100);
         viewport.getCamera().position.set(0,0,0);

--- a/core/test/com/tds/platform/FakeGraphicsContext.java
+++ b/core/test/com/tds/platform/FakeGraphicsContext.java
@@ -1,0 +1,31 @@
+package com.tds.platform;
+
+public class FakeGraphicsContext implements GraphicsContext {
+    private float deltaTime;
+    private int width;
+    private int height;
+
+    public void setDeltaTime(float deltaTime) {
+        this.deltaTime = deltaTime;
+    }
+
+    public void setSize(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    @Override
+    public float getDeltaTime() {
+        return deltaTime;
+    }
+
+    @Override
+    public int getWidth() {
+        return width;
+    }
+
+    @Override
+    public int getHeight() {
+        return height;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GraphicsContext` interface and `GdxGraphicsContext` implementation to abstract screen timing and size
- Inject `GraphicsContext` into HUD, Admin, Virus, and ParticleSystem
- Provide test-only `FakeGraphicsContext` with new unit tests for particle processing and HUD layout
- Avoid direct `Gdx.graphics` usage in tests and document the `GraphicsContext` pattern

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a6b3099c8325b5b8eb0bb98cbc04