### PR TITLE
Add pre-commit formatting configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-google-java-format
+    rev: v1.17.0
+    hooks:
+      - id: google-java-format
+        files: \.java$

--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ Verify with:
 ./gradlew desktop:run
 ```
 
+## Code Style
+This project uses [pre-commit](https://pre-commit.com/) with [google-java-format](https://github.com/google/google-java-format) to enforce consistent formatting for all Java files.
+
+Install pre-commit (once per machine):
+
+```bash
+pip install pre-commit
+```
+
+Set up the git hook:
+
+```bash
+pre-commit install
+```
+
+Format the entire codebase:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Development
 Game code that needs frame timing or screen dimensions should depend on the `GraphicsContext` interface rather than accessing `Gdx.graphics` directly. The `core` module provides a `GdxGraphicsContext` implementation and tests can use `FakeGraphicsContext` to control values.
 


### PR DESCRIPTION
## Summary
- add pre-commit config using google-java-format
- document how to install and run pre-commit for code formatting

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: Username for 'https://github.com')*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a0d8513c8325b4cc6637da7e2567