### PR TITLE
Show centered game over screen with scores

### DIFF
--- a/core/src/com/tds/HUD.java
+++ b/core/src/com/tds/HUD.java
@@ -64,7 +64,11 @@ public class HUD {
     }
 
     public void gameOver(Batch batch, BitmapFont pen) {
-        pen.draw(batch, "GAME OVER", graphics.getHeight() / 2f, graphics.getWidth() / 2f);
+        float centerX = graphics.getWidth() / 2f;
+        float centerY = graphics.getHeight() / 2f;
+        pen.draw(batch, "GAME OVER", centerX, centerY);
+        pen.draw(batch, score.concat(Integer.toString(totalScore)), centerX, centerY - 20);
+        pen.draw(batch, highScoreLabel.concat(Integer.toString(highScore)), centerX, centerY - 40);
     }
 
     /**

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -35,6 +35,7 @@ public class GameScreen extends ScreenAdapter {
     private Wall[] walls;
     private int level;
     private Virus v1;
+    private boolean gameOver;
 
     private final OrthographicCamera camera;
     private final Viewport viewport;
@@ -99,17 +100,28 @@ public class GameScreen extends ScreenAdapter {
         temp.setSize(wallWidth, worldHeight - gap);
         temp.setPosition(worldWidth - wallWidth, gap / 2f);
         walls[3] = temp;
+        gameOver = false;
     }
 
     @Override
     public void render(float delta) {
-        admin.processMovement(virusList, viewport);
         Gdx.gl.glClearColor(.1f, .1f, .1f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
         if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
             Gdx.app.exit();
         }
+
+        if (gameOver) {
+            renderStrategy.apply(game.batch);
+            game.batch.begin();
+            game.batch.draw(background, 0, 0, viewport.getWorldWidth(), viewport.getWorldHeight());
+            hud.gameOver(game.batch, pen);
+            game.batch.end();
+            return;
+        }
+
+        admin.processMovement(virusList, viewport);
         hud.setCurrentLives(admin.getLives());
 
         for (Wall wall : walls) {
@@ -126,7 +138,9 @@ public class GameScreen extends ScreenAdapter {
                 admin.setPosition(viewport.getWorldWidth() / 2, viewport.getWorldHeight() / 2);
                 admin.setLives(admin.getLives() - 1);
                 if (admin.getLives() <= 0) {
-                    Gdx.app.exit();
+                    game.submitScore(hud.getTotalScore());
+                    hud.setHighScore(game.getHighScore());
+                    gameOver = true;
                 }
             }
         }

--- a/core/test/com/tds/HUDGameOverTest.java
+++ b/core/test/com/tds/HUDGameOverTest.java
@@ -1,0 +1,92 @@
+package com.tds;
+
+import static org.junit.Assert.*;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.tds.platform.FakeGraphicsContext;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HUDGameOverTest {
+    private static class RecordingFont extends BitmapFont {
+        final java.util.List<Float> xs = new java.util.ArrayList<>();
+        final java.util.List<Float> ys = new java.util.ArrayList<>();
+
+        RecordingFont() {
+            super(new BitmapFontData(), new TextureRegion(new DummyTexture()), false);
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.GlyphLayout draw(Batch batch, CharSequence str, float x, float y) {
+            xs.add(x);
+            ys.add(y);
+            return null;
+        }
+    }
+
+    private static class DummyTexture extends com.badlogic.gdx.graphics.Texture {
+        public DummyTexture() {
+            super();
+        }
+
+        @Override
+        public int getWidth() {
+            return 1;
+        }
+
+        @Override
+        public int getHeight() {
+            return 1;
+        }
+
+        @Override
+        public int getDepth() {
+            return 0;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.TextureData getTextureData() {
+            return null;
+        }
+
+        @Override
+        public boolean isManaged() {
+            return false;
+        }
+
+        @Override
+        protected void reload() {}
+    }
+
+    @Before
+    public void setup() {
+        if (Gdx.app == null) {
+            HeadlessApplicationConfiguration config = new HeadlessApplicationConfiguration();
+            new HeadlessApplication(new ApplicationAdapter() {}, config);
+        }
+    }
+
+    @Test
+    public void drawsGameOverCentered() {
+        FakeGraphicsContext graphics = new FakeGraphicsContext();
+        graphics.setSize(800, 600);
+        HUD hud = new HUD(graphics);
+        RecordingFont font = new RecordingFont();
+        hud.gameOver(null, font);
+        assertEquals(3, font.xs.size());
+        assertEquals(400f, font.xs.get(0), 0.001f);
+        assertEquals(300f, font.ys.get(0), 0.001f);
+        assertEquals(400f, font.xs.get(1), 0.001f);
+        assertEquals(280f, font.ys.get(1), 0.001f);
+        assertEquals(400f, font.xs.get(2), 0.001f);
+        assertEquals(260f, font.ys.get(2), 0.001f);
+        font.dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Display final score and high score in `HUD.gameOver`
- Keep the game over screen active until ESC is pressed and refresh high score immediately
- Expand unit test to validate all game over draw positions

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c0ce790c8325a85a5814736abc96