### PR TITLE
Fix entity collision radius updates

### DIFF
--- a/core/src/com/tds/Entity.java
+++ b/core/src/com/tds/Entity.java
@@ -25,7 +25,8 @@ public class Entity extends Sprite {
 
     public Entity(float health, float speed, Texture texture, int srcX, int srcY, int srcWidth, int srcHeight) {
         super(texture, srcX, srcY, srcWidth, srcHeight);
-        boundingCircle = new Circle(getX(), getY(), srcWidth);
+        setBounds(getX(), getY(), srcWidth, srcHeight);
+        boundingCircle = new Circle(getX(), getY(), srcWidth / 2f);
         this.health = health;
         this.speed = speed;
     }
@@ -34,6 +35,39 @@ public class Entity extends Sprite {
         super();
         this.health = health;
         this.speed = speed;
+        boundingCircle = new Circle(getX(), getY(), getWidth() / 2f);
+    }
+
+    @Override
+    public void setBounds(float x, float y, float width, float height) {
+        super.setBounds(x, y, width, height);
+        if (boundingCircle != null) {
+            boundingCircle.setRadius(getWidth() / 2f);
+        }
+    }
+
+    @Override
+    public void setSize(float width, float height) {
+        super.setSize(width, height);
+        if (boundingCircle != null) {
+            boundingCircle.setRadius(getWidth() / 2f);
+        }
+    }
+
+    @Override
+    public void setScale(float scaleXY) {
+        super.setScale(scaleXY);
+        if (boundingCircle != null) {
+            boundingCircle.setRadius(getWidth() / 2f);
+        }
+    }
+
+    @Override
+    public void setScale(float scaleX, float scaleY) {
+        super.setScale(scaleX, scaleY);
+        if (boundingCircle != null) {
+            boundingCircle.setRadius(getWidth() / 2f);
+        }
     }
 
     public float getHealth() {

--- a/core/test/com/tds/EntityCollisionTest.java
+++ b/core/test/com/tds/EntityCollisionTest.java
@@ -1,0 +1,59 @@
+package com.tds;
+
+import static org.junit.Assert.*;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.TextureData;
+import org.junit.Test;
+
+public class EntityCollisionTest {
+    private static class DummyTexture extends Texture {
+        public DummyTexture() {
+            super();
+        }
+
+        @Override
+        public int getWidth() {
+            return 128;
+        }
+
+        @Override
+        public int getHeight() {
+            return 128;
+        }
+
+        @Override
+        public int getDepth() {
+            return 0;
+        }
+
+        @Override
+        public TextureData getTextureData() {
+            return null;
+        }
+
+        @Override
+        public boolean isManaged() {
+            return false;
+        }
+
+        @Override
+        protected void reload() {}
+    }
+
+    @Test
+    public void collisionsUseExpectedRadii() {
+        Texture texture = new DummyTexture();
+        Entity e1 = new Entity(1, 0, texture, 0, 0, 64, 64);
+        Entity e2 = new Entity(1, 0, texture, 0, 0, 64, 64);
+
+        e1.getBoundingCircle().setPosition(0, 0);
+        e2.getBoundingCircle().setPosition(64, 0);
+        assertFalse(e1.checkCollision(e2));
+
+        e1.setSize(128, 128);
+        e1.getBoundingCircle().setPosition(0, 0);
+        e2.getBoundingCircle().setPosition(90, 0);
+        assertTrue(e1.checkCollision(e2));
+    }
+}


### PR DESCRIPTION
## Summary
- initialize bounding circle radius to half sprite width
- refresh radius when sprite bounds, size or scale change
- add unit test covering collision radius updates

## Testing
- `gradle wrapper --gradle-version 8.9`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c5608b08832590d69ce472d558ab