### PR TITLE
Fix desktop launcher to run in windowed mode

### DIFF
--- a/desktop/src/com/tds/desktop/DesktopLauncher.java
+++ b/desktop/src/com/tds/desktop/DesktopLauncher.java
@@ -1,6 +1,5 @@
 package com.tds.desktop;
 
-import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.tds.GameBootstrap;
@@ -10,10 +9,11 @@ import com.tds.screen.OrthographicRenderStrategy;
 public class DesktopLauncher {
     public static void main(String[] arg) {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
-        DisplayMode displayMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
-        config.setFullscreenMode(displayMode);
+        int width = 800;
+        int height = 600;
+        config.setWindowedMode(width, height);
         TDS game = new GameBootstrap()
-                .withRenderStrategy(new OrthographicRenderStrategy(displayMode.width, displayMode.height))
+                .withRenderStrategy(new OrthographicRenderStrategy(width, height))
                 .bootstrap();
         new Lwjgl3Application(game, config);
     }


### PR DESCRIPTION
## Summary
- Start desktop client in fixed 800x600 window instead of fullscreen.

## Testing
- `pre-commit run --files desktop/src/com/tds/desktop/DesktopLauncher.java`
- `./gradlew test`
- `./gradlew desktop:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cb89aad883259d971433ca199651