### PR TITLE
Add start and quit input actions

### DIFF
--- a/core/src/com/tds/input/InputHandler.java
+++ b/core/src/com/tds/input/InputHandler.java
@@ -24,6 +24,8 @@ public class InputHandler extends InputAdapter implements InputService {
         bindings.put(Action.MOVE_DOWN, Input.Keys.S);
         bindings.put(Action.DASH, Input.Keys.SHIFT_LEFT);
         bindings.put(Action.FIRE, Input.Buttons.LEFT);
+        bindings.put(Action.START, Input.Keys.ENTER);
+        bindings.put(Action.QUIT, Input.Keys.ESCAPE);
 
         for (Action action : Action.values()) {
             states.put(action, false);

--- a/core/src/com/tds/input/InputService.java
+++ b/core/src/com/tds/input/InputService.java
@@ -14,7 +14,9 @@ public interface InputService extends InputProcessor {
         MOVE_UP,
         MOVE_DOWN,
         DASH,
-        FIRE
+        FIRE,
+        START,
+        QUIT
     }
 
     /**

--- a/core/src/com/tds/screen/GameScreen.java
+++ b/core/src/com/tds/screen/GameScreen.java
@@ -1,7 +1,6 @@
 package com.tds.screen;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -17,6 +16,7 @@ import com.tds.Wall;
 import com.tds.assets.AnimationSet;
 import com.tds.assets.AnimationSetFactory;
 import com.tds.input.InputService;
+import com.tds.input.InputService.Action;
 import com.tds.platform.GdxGraphicsContext;
 import com.tds.platform.GraphicsContext;
 import com.tds.weapons.ParticleSystem;
@@ -111,7 +111,7 @@ public class GameScreen extends ScreenAdapter {
         Gdx.gl.glClearColor(.1f, .1f, .1f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-        if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
+        if (input.isActionPressed(Action.QUIT)) {
             Gdx.app.exit();
         }
 

--- a/core/src/com/tds/screen/MenuScreen.java
+++ b/core/src/com/tds/screen/MenuScreen.java
@@ -1,12 +1,12 @@
 package com.tds.screen;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.tds.TDS;
 import com.tds.input.InputService;
+import com.tds.input.InputService.Action;
 
 public class MenuScreen extends ScreenAdapter {
     private final TDS game;
@@ -34,7 +34,7 @@ public class MenuScreen extends ScreenAdapter {
         font.draw(game.batch, "Press ENTER to Start", 100, 100);
         game.batch.end();
 
-        if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
+        if (input.isActionPressed(Action.START)) {
             game.setScreen(screenFactory.createGameScreen());
         }
     }

--- a/core/test/com/tds/screen/GameScreenQuitActionTest.java
+++ b/core/test/com/tds/screen/GameScreenQuitActionTest.java
@@ -1,0 +1,44 @@
+package com.tds.screen;
+
+import static org.mockito.Mockito.*;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.tds.TDS;
+import com.tds.input.InputHandler;
+import com.tds.input.InputService.Action;
+import org.junit.Test;
+
+public class GameScreenQuitActionTest {
+
+    @Test
+    public void pressingEscapeExitsApplication() {
+        InputHandler input = new InputHandler();
+        Application app = mock(Application.class);
+        Gdx.app = app;
+
+        RenderStrategy render = mock(RenderStrategy.class);
+        OrthographicCamera cam = new OrthographicCamera();
+        ScreenViewport viewport = new ScreenViewport(cam);
+        when(render.getCamera()).thenReturn(cam);
+        when(render.getViewport()).thenReturn(viewport);
+
+        TDS game = mock(TDS.class);
+        GameScreen screen = new GameScreen(game, input, render) {
+            @Override
+            public void render(float delta) {
+                if (input.isActionPressed(Action.QUIT)) {
+                    Gdx.app.exit();
+                }
+            }
+        };
+
+        input.keyDown(Input.Keys.ESCAPE);
+        screen.render(0f);
+
+        verify(app).exit();
+    }
+}

--- a/core/test/com/tds/screen/MenuScreenTest.java
+++ b/core/test/com/tds/screen/MenuScreenTest.java
@@ -11,13 +11,13 @@ import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.backends.headless.HeadlessApplication;
 import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
-import com.badlogic.gdx.backends.headless.mock.input.MockInput;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.tds.TDS;
 import com.tds.input.InputHandler;
 import com.tds.input.InputService;
+import com.tds.input.InputService.Action;
 import com.tds.score.ScoreRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,13 +72,6 @@ public class MenuScreenTest {
             called = true;
             produced = new GameScreen(game, input, new OrthographicRenderStrategy(800, 600));
             return produced;
-        }
-    }
-
-    private static class TestInput extends MockInput {
-        @Override
-        public boolean isKeyJustPressed(int keycode) {
-            return keycode == Input.Keys.ENTER;
         }
     }
 
@@ -158,16 +151,18 @@ public class MenuScreenTest {
     private static class TestableMenuScreen extends MenuScreen {
         private final TDS g;
         private final ScreenFactory f;
+        private final InputService i;
 
         TestableMenuScreen(TDS g, InputService i, ScreenFactory f) {
             super(g, i, f);
             this.g = g;
+            this.i = i;
             this.f = f;
         }
 
         @Override
         public void render(float delta) {
-            if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
+            if (i.isActionPressed(Action.START)) {
                 g.setScreen(f.createGameScreen());
             }
         }
@@ -175,12 +170,12 @@ public class MenuScreenTest {
 
     @Test
     public void pressingEnterRequestsNewScreen() {
-        InputService inputService = new InputHandler();
+        InputHandler inputService = new InputHandler();
         StubGame game = new StubGame(inputService, new StubScoreRepository());
         FakeFactory factory = new FakeFactory(game, inputService);
         MenuScreen menu = new TestableMenuScreen(game, inputService, factory);
 
-        Gdx.input = new TestInput();
+        inputService.keyDown(Input.Keys.ENTER);
         menu.render(0f);
 
         assertTrue(factory.called);


### PR DESCRIPTION
## Summary
- add START and QUIT actions to input service and bind them to ENTER and ESCAPE
- use input service for start/quit in menu and game screens
- test start and quit actions through InputService

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d766b3388325baf1cc617927182d