### PR TITLE
Ensure MenuScreen receives keyboard input

### DIFF
--- a/core/src/com/tds/screen/MenuScreen.java
+++ b/core/src/com/tds/screen/MenuScreen.java
@@ -23,6 +23,7 @@ public class MenuScreen extends ScreenAdapter {
     @Override
     public void show() {
         font = new BitmapFont();
+        Gdx.input.setInputProcessor(input);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Set the input processor in `MenuScreen` to forward key events to `InputService`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f87adbf0832584fc07c475a27472