### PR TITLE
Use display mode dimensions in desktop launcher

### DIFF
--- a/desktop/src/com/tds/desktop/DesktopLauncher.java
+++ b/desktop/src/com/tds/desktop/DesktopLauncher.java
@@ -1,5 +1,6 @@
 package com.tds.desktop;
 
+import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.tds.GameBootstrap;
@@ -9,8 +10,9 @@ import com.tds.screen.OrthographicRenderStrategy;
 public class DesktopLauncher {
     public static void main(String[] arg) {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
-        int width = 800;
-        int height = 600;
+        DisplayMode mode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+        int width = mode.width;
+        int height = mode.height;
         config.setWindowedMode(width, height);
         TDS game = new GameBootstrap()
                 .withRenderStrategy(new OrthographicRenderStrategy(width, height))


### PR DESCRIPTION
## Summary
- Use current display mode to determine window dimensions
- Forward display mode width and height to `OrthographicRenderStrategy`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f9d00a888325a4ca7122de449d2e