### PR TITLE
Remove broad exception handling from projectile system

### DIFF
--- a/core/src/com/tds/weapons/ProjectileSystem.java
+++ b/core/src/com/tds/weapons/ProjectileSystem.java
@@ -61,18 +61,14 @@ public class ProjectileSystem implements ParticleSystem {
                 particles.remove(i);
                 continue;
             }
-            try {
-                for (Virus e : enemies) {
-                    if (e.getBoundingRectangle().overlaps(p.getBoundingRectangle())) {
-                        e.setHealth(e.getHealth() - 1);
-                        if (e.getHealth() <= 0) {
-                            e.setStatus(false);
-                        }
-                        p.setHealth(0);
+            for (Virus e : enemies) {
+                if (e.getBoundingRectangle().overlaps(p.getBoundingRectangle())) {
+                    e.setHealth(e.getHealth() - 1);
+                    if (e.getHealth() <= 0) {
+                        e.setStatus(false);
                     }
+                    p.setHealth(0);
                 }
-            } catch (Exception t) {
-
             }
         }
     }

--- a/core/test/com/tds/weapons/ProjectileSystemTest.java
+++ b/core/test/com/tds/weapons/ProjectileSystemTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.tds.Virus;
 import com.tds.platform.FakeGraphicsContext;
+import com.tds.platform.GraphicsContext;
 import java.util.ArrayList;
 import org.junit.Test;
 
@@ -52,5 +53,29 @@ public class ProjectileSystemTest {
         assertEquals(1, system.particles.size());
         system.process(new ArrayList<Virus>());
         assertEquals(0, system.particles.size());
+    }
+
+    private static class ExplodingVirus extends Virus {
+        public ExplodingVirus(com.badlogic.gdx.graphics.Texture texture, GraphicsContext graphics) {
+            super(texture, 0f, 0, 0, graphics);
+        }
+
+        @Override
+        public com.badlogic.gdx.math.Rectangle getBoundingRectangle() {
+            throw new RuntimeException("boom");
+        }
+    }
+
+    @Test
+    public void processPropagatesRuntimeExceptions() {
+        FakeGraphicsContext graphics = new FakeGraphicsContext();
+        graphics.setDeltaTime(1f);
+        ProjectileSystem system = new ProjectileSystem(new DummyTexture(), graphics);
+        system.process(new ArrayList<Virus>());
+        system.shoot(1f, 0f, 0f, 0f, 0f, 0f);
+        graphics.setDeltaTime(0.1f);
+        ArrayList<Virus> enemies = new ArrayList<>();
+        enemies.add(new ExplodingVirus(new DummyTexture(), graphics));
+        assertThrows(RuntimeException.class, () -> system.process(enemies));
     }
 }


### PR DESCRIPTION
## Summary
- Drop blanket exception catch when processing projectiles to allow failures to propagate
- Add test verifying unexpected runtime exceptions bubble up during processing

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe22a3188325bfc233e186fe4a8d